### PR TITLE
Enable yaml format file

### DIFF
--- a/lib/schema_conformist/driver.rb
+++ b/lib/schema_conformist/driver.rb
@@ -3,11 +3,15 @@ module SchemaConformist
     include Committee::Rails::Test::Methods
 
     def committee_schema
-      @committee_schema ||=
-        begin
-          schema_hash = JSON.parse(File.read(schema_path))
-          driver.parse(schema_hash)
-        end
+      @committee_schema ||= driver.parse(schema_hash)
+    end
+
+    def schema_hash(schema_data = File.read(schema_path))
+      if %w(.yaml .yml).include?(File.extname(schema_path))
+        YAML.safe_load(schema_data)
+      else
+        JSON.parse(schema_data)
+      end
     end
 
     def schema_path

--- a/test/driver_test.rb
+++ b/test/driver_test.rb
@@ -51,4 +51,29 @@ class SchemaConformist::Driver::Test < ActiveSupport::TestCase
       DriverTestClass.new.schema_path
     end
   end
+
+  test '#schema_hash with json format argument returns correct hash data' do
+    Rails.application.config.schema_conformist.schema_path = Rails.root.join('public', 'swagger.json')
+    json_data = <<~JSON
+    {
+      "swagger": "2.0",
+      "info": {
+        "description": "This is a dummy app"
+      }
+    }
+    JSON
+    expected_hash = {'swagger' => '2.0', 'info' => { 'description' => 'This is a dummy app' }}
+    assert_equal expected_hash, DriverTestClass.new.schema_hash(json_data)
+  end
+
+  test '#schema_hash with yaml format argument returns correct hash data' do
+    Rails.application.config.schema_conformist.schema_path = Rails.root.join('public', 'swagger.yaml')
+    yaml_data = <<~YAML
+    swagger: "2.0"
+    info:
+      description: "This is a dummy app"
+    YAML
+    expected_hash = {'swagger' => '2.0', 'info' => { 'description' => 'This is a dummy app' }}
+    assert_equal expected_hash, DriverTestClass.new.schema_hash(yaml_data)
+  end
 end

--- a/test/driver_test.rb
+++ b/test/driver_test.rb
@@ -5,7 +5,7 @@ class SchemaConformist::Driver::Test < ActiveSupport::TestCase
     include SchemaConformist::Driver
   end
 
-  teardown do
+  setup do
     Rails.application.config.schema_conformist.driver = :hyper_schema
     Rails.application.config.schema_conformist.ignored_api_paths = []
     Rails.application.config.schema_conformist.schema_path = nil

--- a/test/dummy/public/swagger.yaml
+++ b/test/dummy/public/swagger.yaml
@@ -1,0 +1,99 @@
+---
+swagger: '2.0'
+info:
+  description: This is a dummy app
+  version: 1.0.0
+  title: Dummy app
+host: petstore.swagger.io
+schemes:
+- http
+consumes:
+- application/json
+produces:
+- application/json
+paths:
+  "/products":
+    get:
+      description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Product"
+    post:
+      description: ''
+      parameters:
+      - in: body
+        name: body
+        description: ''
+        required: true
+        schema:
+          "$ref": "#/definitions/Product"
+      responses:
+        '201':
+          description: ''
+          schema:
+            "$ref": "#/definitions/Product"
+  "/products/{productId}":
+    get:
+      description: ''
+      parameters:
+      - name: productId
+        in: path
+        description: ''
+        required: true
+        type: integer
+      responses:
+        '200':
+          description: ''
+          schema:
+            "$ref": "#/definitions/Product"
+    put:
+      description: ''
+      parameters:
+      - name: productId
+        in: path
+        description: ''
+        required: true
+        type: integer
+      - in: body
+        name: body
+        description: ''
+        required: true
+        schema:
+          "$ref": "#/definitions/Product"
+      responses:
+        '200':
+          description: ''
+          schema:
+            "$ref": "#/definitions/Product"
+    delete:
+      description: ''
+      parameters:
+      - name: productId
+        in: path
+        description: ''
+        required: true
+        type: integer
+      responses:
+        '204':
+          description: ''
+definitions:
+  Product:
+    type: object
+    required:
+    - name
+    - price
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+      price:
+        type: integer
+      stock_count:
+        type:
+        - integer
+        - 'null'

--- a/test/dummy/test/controllers/products_controller_with_open_api_2_yaml_test.rb
+++ b/test/dummy/test/controllers/products_controller_with_open_api_2_yaml_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class ProductsControllerWithOpenAPI2YamlTest < ActionDispatch::IntegrationTest
+  setup do
+    Rails.application.config.schema_conformist.driver = :open_api_2
+    Rails.application.config.schema_conformist.ignored_api_paths = []
+    Rails.application.config.schema_conformist.schema_path = Rails.root.join('public', 'swagger.yaml')
+  end
+
+  test 'GET /products' do
+    get products_url, as: :json
+  end
+
+  test 'GET /products/:id' do
+    get product_url(products(:one)), as: :json
+  end
+
+  test "POST /products" do
+    assert_difference('Product.count') do
+      post products_url, params: { product: { name: 'new product', price: 100, stock_count: 100 } }, as: :json
+    end
+  end
+
+  test "PUT /products/:id" do
+    product = products(:one)
+    put product_url(product), params: { product: { name: product.name, price: product.price, stock_count: 100 } }, as: :json
+    assert_response 200
+  end
+
+  test "DELETE /products/:id" do
+    assert_difference('Product.count', -1) do
+      delete product_url(products(:one)), as: :json
+    end
+  end
+
+  test "GET /private" do
+    Rails.application.config.schema_conformist.ignored_api_paths << /private/
+    get private_path
+  end
+
+  test "GET /private without ignored API paths" do
+    assert_raises Committee::InvalidResponse do
+      get private_path
+    end
+  end
+end


### PR DESCRIPTION
YAML can be used to represent a Swagger specification file.  
This pull request enable to use yaml format swagger file for schema_conformist.  

```ruby
Rails.application.config.schema_conformist.driver = :open_api_2
Rails.application.config.schema_conformist.schema_path = Rails.root.join('doc', 'swagger.yml') # `swagger.yaml` is also available.
```