### PR TITLE
Use Committee v3

### DIFF
--- a/lib/schema_conformist.rb
+++ b/lib/schema_conformist.rb
@@ -1,5 +1,4 @@
 require 'committee'
-require 'committee/rails'
 require 'schema_conformist/railtie'
 require 'schema_conformist/driver'
 require 'schema_conformist/process_with_assertion'

--- a/lib/schema_conformist/driver.rb
+++ b/lib/schema_conformist/driver.rb
@@ -1,6 +1,6 @@
 module SchemaConformist
   module Driver
-    include Committee::Rails::Test::Methods
+    include Committee::Test::Methods
 
     def committee_schema
       @committee_schema ||= driver.parse(schema_hash)
@@ -46,6 +46,14 @@ module SchemaConformist
 
     def driver_name
       Rails.application.config.schema_conformist.driver
+    end
+
+    def request_object
+      request
+    end
+
+    def response_data
+      [response.status, response.headers, response.body]
     end
   end
 end

--- a/lib/schema_conformist/driver.rb
+++ b/lib/schema_conformist/driver.rb
@@ -6,6 +6,10 @@ module SchemaConformist
       @committee_schema ||= driver.parse(schema_hash)
     end
 
+    def committee_options
+      { schema: committee_schema }
+    end
+
     def schema_hash(schema_data = File.read(schema_path))
       if %w(.yaml .yml).include?(File.extname(schema_path))
         YAML.safe_load(schema_data)

--- a/schema_conformist.gemspec
+++ b/schema_conformist.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   s.add_dependency 'rails'
-  s.add_dependency 'committee-rails'
   s.add_dependency 'committee', '~> 3.0.1'
 
   s.add_development_dependency 'sqlite3', '~> 1.3.6'

--- a/schema_conformist.gemspec
+++ b/schema_conformist.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails'
   s.add_dependency 'committee-rails'
-  s.add_dependency 'committee', '~> 2.5.1'
+  s.add_dependency 'committee', '~> 3.0.1'
 
   s.add_development_dependency 'sqlite3', '~> 1.3.6'
 end


### PR DESCRIPTION
Use latest Committee, which is currently [v3.0.1](https://github.com/interagent/committee/tree/v3.0.1).

- Update Committee dependency
- Remove Committee::Rails dependency
  - It is enough for this gem to define `Driver#request_object` and `Driver#request_data` with Committee v3