### PR TITLE
Drop Ruby 2.4.x which has support ended and add 3.0.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.4.x', '2.5.x', '2.6.x', '2.7.x']
+        ruby: ['2.5.x', '2.6.x', '2.7.x', '3.0.x']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Lint Code Base
         uses: docker://github/super-linter:v3
         env:


### PR DESCRIPTION
Drop Ruby 2.4 and add Ruby 3.0.x to matrix.

cf. https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/